### PR TITLE
feat: actualizar política de seguridad de origen de datos

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -27,7 +27,7 @@
   content="
       default-src 'self' https: localhost:* *.portaloas.udistrital.edu.co; 
       script-src 'unsafe-inline' 'unsafe-eval' https: localhost:* *.portaloas.udistrital.edu.co; 
-      connect-src 'self' https: localhost:* ws://localhost:* *.portaloas.udistrital.edu.co data:;
+      connect-src 'self' https: localhost:* ws://localhost:* *.portaloas.udistrital.edu.co data: blob:;
       style-src 'unsafe-inline' https: *.portaloas.udistrital.edu.co; 
       img-src 'self' https: data:; 
       object-src 'none';

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -27,7 +27,7 @@
   content="
       default-src 'self' https: localhost:* *.portaloas.udistrital.edu.co; 
       script-src 'unsafe-inline' 'unsafe-eval' https: localhost:* *.portaloas.udistrital.edu.co; 
-      connect-src https: localhost:* ws://localhost:* *.portaloas.udistrital.edu.co; 
+      connect-src 'self' https: localhost:* ws://localhost:* *.portaloas.udistrital.edu.co data:;
       style-src 'unsafe-inline' https: *.portaloas.udistrital.edu.co; 
       img-src 'self' https: data:; 
       object-src 'none';


### PR DESCRIPTION
Actualiza la política de seguridad de origen de datos en el archivo index.ejs para permitir la conexión a 'self' y 'data:'. Esto soluciona un problema de conexión con los datos.

udistrital/sga_documentacion#495